### PR TITLE
Version 1.2

### DIFF
--- a/nealib/src/Archiving/AVFile.cs
+++ b/nealib/src/Archiving/AVFile.cs
@@ -23,33 +23,32 @@ namespace NEA.Archiving
     {
         public string FilePath { get; private set; }
         public string FileName { get; private set; }
-        public string Checksum { get; private set; }
+        public string IndicatedChecksum { get; private set; }
         public string AbsolutePath { get; private set; }
         public ArchiveVersion Archiveversion { get; private set; }
         public AVFileType AvFileType { get; private set; }
 
-        public AVFile(string path, string name, ArchiveVersion archiveversion, string checksum = null)
+        public AVFile(string path, string name, ArchiveVersion archiveversion, string indicatedSum)
         {
             FilePath = path;
             FileName = name;
             Archiveversion = archiveversion;
-            Checksum = checksum;
+            IndicatedChecksum = indicatedSum;
         }
 
-        public bool ValidateChecksum(string checksumIn)
+        public bool ValidateIndicatedChecksum()
         {
-            if(Checksum == null)
+            if (IndicatedChecksum == null)
+                throw new Exception("IndicatedChecksum is not set, cannot validate checksum");
+            
+            using (var md5 = MD5.Create())
             {
-                using (var md5 = MD5.Create())
+                using (var stream = File.OpenRead(this.GetAbsolutePath()))
                 {
-                    using (var stream = File.OpenRead(this.GetAbsolutePath()))
-                    {
-                        Checksum = md5.ComputeHash(stream).ToString();
-                    }
+                    var hash = md5.ComputeHash(stream);
+                    return IndicatedChecksum == BitConverter.ToString(hash).Replace("-", "").ToUpperInvariant();
                 }
             }
-
-            return Checksum == checksumIn;
         }
 
         public string GetAbsolutePath()

--- a/nealib/src/Archiving/ArchiveVersion.cs
+++ b/nealib/src/Archiving/ArchiveVersion.cs
@@ -72,6 +72,8 @@ namespace NEA.Archiving
     /// </summary>
     public class ArchiveVersion
     {
+        public List<string> Medias { get; set; }
+
         /// <summary>
         /// The tables of the archive version.
         /// </summary>

--- a/nealib/src/Archiving/ArchiveVersionInfo.cs
+++ b/nealib/src/Archiving/ArchiveVersionInfo.cs
@@ -5,7 +5,7 @@
     {
         public AVRuleSet AvRuleSet { get; private set; }
         public string Id { get; private set; }
-        public string  FolderPath { get; private set; }
+        public string FolderPath { get; private set; }
 
         public ArchiveVersionInfo(string id, string path, AVRuleSet avRuleSet)
         {

--- a/nealib/src/Archiving/ArchiveVersionInfo.cs
+++ b/nealib/src/Archiving/ArchiveVersionInfo.cs
@@ -13,5 +13,10 @@
             Id = id;
             AvRuleSet = avRuleSet;
         }
+
+        public ArchiveVersionInfo()
+        {
+
+        }
     }
 }

--- a/nealib/src/Utility/ArchiveversionIdentifier.cs
+++ b/nealib/src/Utility/ArchiveversionIdentifier.cs
@@ -10,9 +10,9 @@ namespace NEA.Utility
     public class ArchiveVersionIdentifier
     {
         private readonly string _folderPattern1007 = @"^AVID\.[A-ZØÆÅ]{2,4}\.\d{1,5}$";
-        private readonly string _folderPattern1007NoBase = @"^AVID\.[A-ZØÆÅ]{2,4}\.\d{1,5}.1$";
+        private readonly string _folderPattern1007FirstMedia = @"^AVID\.[A-ZØÆÅ]{2,4}\.\d{1,5}.1$";
         private readonly string _folderPattern342 = @"^000\d{5}$";
-        private readonly string _folderPattern342NoBase = @"^\d{5}001$";
+        private readonly string _folderPattern342FirstMedia = @"^\d{5}001$";
 
         private readonly IFileSystem _fileSystem;
 
@@ -59,7 +59,7 @@ namespace NEA.Utility
             /*
              * Archiveversion 1007 without base folder
              */
-            else if ((Regex.IsMatch(curDir.Name, _folderPattern1007NoBase, RegexOptions.IgnoreCase)))
+            else if ((Regex.IsMatch(curDir.Name, _folderPattern1007FirstMedia, RegexOptions.IgnoreCase)))
             {
                 var mainDir = _fileSystem.DirectoryInfo.FromDirectoryName(Path.Combine(curDir.FullName, "Indices"));
                 if (mainDir.Exists) { 
@@ -70,7 +70,7 @@ namespace NEA.Utility
             /*
              * Archiveversion 342 without base folder
              */
-            else if ((Regex.IsMatch(curDir.Name, _folderPattern342NoBase, RegexOptions.IgnoreCase)))
+            else if ((Regex.IsMatch(curDir.Name, _folderPattern342FirstMedia, RegexOptions.IgnoreCase)))
             {
                 var mainFile = _fileSystem.FileInfo.FromFileName(curDir.FullName + "\\arkver.tab");
                 if (mainFile.Exists) {

--- a/nealib/src/Utility/ArchiveversionIdentifier.cs
+++ b/nealib/src/Utility/ArchiveversionIdentifier.cs
@@ -63,7 +63,7 @@ namespace NEA.Utility
             {
                 var mainDir = _fileSystem.DirectoryInfo.FromDirectoryName(Path.Combine(curDir.FullName, "Indices"));
                 if (mainDir.Exists) { 
-                    avFolderIdType = new ArchiveVersionInfo(curDir.Name.Substring(0, curDir.Name.Length - 2), curDir.FullName, AVRuleSet.BKG1007);
+                    avFolderIdType = new ArchiveVersionInfo(curDir.Name.Substring(0, curDir.Name.Length - 2), Directory.GetParent(curDir.FullName).FullName, AVRuleSet.BKG1007);
                     return true;
                 }
             }
@@ -74,7 +74,7 @@ namespace NEA.Utility
             {
                 var mainFile = _fileSystem.FileInfo.FromFileName(curDir.FullName + "\\arkver.tab");
                 if (mainFile.Exists) {
-                    avFolderIdType = new ArchiveVersionInfo("000" + curDir.Name.Substring(0, curDir.Name.Length - 3), curDir.FullName, AVRuleSet.BKG342);
+                    avFolderIdType = new ArchiveVersionInfo("000" + curDir.Name.Substring(0, curDir.Name.Length - 3), Directory.GetParent(curDir.FullName).FullName, AVRuleSet.BKG342);
                     return true;
                 }
             }
@@ -102,6 +102,24 @@ namespace NEA.Utility
             }
             avFolderList.Sort((x, y) => string.Compare(x.Id, y.Id));
             return avFolderList;
+        }
+
+        public List<string> GetArciveversionMediaFolders(ArchiveVersionInfo avInfo)
+        {
+            List<string> medias = new List<string>();
+            string folderToCheck = avInfo.FolderPath;
+
+            foreach (string potentialPath in Directory.EnumerateDirectories(folderToCheck))
+            {
+                string folderName = new DirectoryInfo(potentialPath).Name;
+
+                if (Regex.IsMatch(folderName, _folderPattern1007FirstMedia) && potentialPath.Contains(avInfo.Id))
+                {
+                    medias.Add(folderName);
+                }
+            }
+
+            return medias;
         }
     }
 }

--- a/nealib/src/Utility/ArchiveversionIdentifier.cs
+++ b/nealib/src/Utility/ArchiveversionIdentifier.cs
@@ -21,6 +21,11 @@ namespace NEA.Utility
             _fileSystem = fileSystem;
         }
 
+        public ArchiveVersionIdentifier()
+        {
+            _fileSystem = new FileSystem();
+        }
+
         /// <summary>
         /// Checks wether a given folder is an archive version
         /// </summary>

--- a/nealib/src/Utility/FileIndexReader.cs
+++ b/nealib/src/Utility/FileIndexReader.cs
@@ -2,112 +2,42 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Xml;
 using System.Xml.Linq;
 
 namespace NEA.Utility
 {
 
-    public class FileIndexReader : IDisposable
+    public class FileIndexReader
     {
-        Stream _stream;
-        XmlReader _xmlReader;
-        XNamespace xmlnsxsi = "http://www.w3.org/2001/XMLSchema-instance";
         ArchiveVersion _archiveversion;
+        FileInfo FilePath;
 
         public FileIndexReader(ArchiveVersion archiveversion)
         {
+            FilePath = new FileInfo(Path.Combine(archiveversion.Path, archiveversion.Id + ".1", "Indices", "fileIndex.xml"));
+            
             _archiveversion = archiveversion;
-            _stream = new FileStream(Path.Combine(archiveversion.Path, "Indices", "fileIndex.xml"), FileMode.Open, FileAccess.Read);
-            _xmlReader = XmlReader.Create(_stream);
+
+            if (!FilePath.Exists)
+            {
+                throw new Exception(String.Format("Could not find fileIndex.xml in this path", FilePath));
+            }
         }
 
         /// <summary>
-        /// Read rows of the table.
+        /// Read files from fileIndex.xml
         /// </summary>
-        /// <param name="rows"></param>
-        /// <param name="n"></param>
-        /// <returns></returns>
-        public int ReadN(out AVFile[] files, int n = 100000, int offset = 0)
+        /// <returns>IEnumerable<AVFile></returns>
+        public IEnumerable<AVFile> ReadFiles()
         {
-            files = new Archiving.AVFile[n];
-            int row = 0;
+            XDocument fileIndex = XDocument.Load(FilePath.FullName);
+            var ns = fileIndex.Root.Name.Namespace;
 
-            while (row < n && _xmlReader.Read())
-            {
-                if (_xmlReader.NodeType == XmlNodeType.Element && _xmlReader.Name.Equals("f"))
-                {
-                    using (XmlReader inner = _xmlReader.ReadSubtree())
-                    {
-                        if (inner.Read())
-                        {
-                            files[row] = new AVFile(
-                                XElement.Load(inner).Element(xmlnsxsi + "foN").Value, 
-                                XElement.Load(inner).Element(xmlnsxsi + "fiN").Value,
-                                _archiveversion);
-                        }
-                    }
-                    row++;
-                }
-            }
-
-            return row;
+            return from f in fileIndex.Descendants(ns.GetName("f"))
+                   select new AVFile(f.Element(ns.GetName("foN")).Value, f.Element(ns.GetName("fiN")).Value, _archiveversion, f.Element(ns.GetName("md5")).Value);
         }
-
-        public IEnumerable<AVFile> Read(int chunkSize = 100000, int offset = 0)
-        {
-            int rowsRead = 0;
-            AVFile[] files;
-
-            while ((rowsRead = ReadN(out files, chunkSize, offset)) > 0)
-            {
-                for (int i = 0; i < rowsRead; i++)
-                {
-                    yield return files[i];
-                }
-            }
-
-            yield break;
-        }
-
-        #region IDisposable Support
-        private bool disposedValue = false; // To detect redundant calls
-
-        protected virtual void Dispose(bool disposing)
-        {
-            if (!disposedValue)
-            {
-                if (disposing)
-                {
-                    _xmlReader.Close();
-                    _xmlReader.Dispose();
-                    _stream.Close();
-                    _stream.Dispose();
-                }
-
-                // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-                // TODO: set large fields to null.
-
-                disposedValue = true;
-            }
-        }
-
-        // TODO: override a finalizer only if Dispose(bool disposing) above has code to free unmanaged resources.
-        ~FileIndexReader()
-        {
-            // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
-            Dispose(false);
-        }
-
-        // This code added to correctly implement the disposable pattern.
-        public void Dispose()
-        {
-            // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
-            Dispose(true);
-            // TODO: uncomment the following line if the finalizer is overridden above.
-            GC.SuppressFinalize(this);
-        }
-        #endregion
     }
 
 }

--- a/nealib/src/Utility/FileIndexReader.cs
+++ b/nealib/src/Utility/FileIndexReader.cs
@@ -16,7 +16,7 @@ namespace NEA.Utility
 
         public FileIndexReader(ArchiveVersion archiveversion)
         {
-            FilePath = new FileInfo(Path.Combine(archiveversion.Path, archiveversion.Id + ".1", "Indices", "fileIndex.xml"));
+            FilePath = new FileInfo(Path.Combine(archiveversion.Path, archiveversion.Medias[0], "Indices", "fileIndex.xml"));
             
             _archiveversion = archiveversion;
 

--- a/nealib/src/Utility/FileIndexReader.cs
+++ b/nealib/src/Utility/FileIndexReader.cs
@@ -36,7 +36,7 @@ namespace NEA.Utility
             var ns = fileIndex.Root.Name.Namespace;
 
             return from f in fileIndex.Descendants(ns.GetName("f"))
-                   select new AVFile(f.Element(ns.GetName("foN")).Value, f.Element(ns.GetName("fiN")).Value, _archiveversion, f.Element(ns.GetName("md5")).Value);
+                   select new AVFile(f.Element(ns.GetName("foN")).Value, f.Element(ns.GetName("fiN")).Value, f.Element(ns.GetName("md5")).Value);
         }
     }
 


### PR DESCRIPTION
Simplified and more usable API for classes:

- AVFile (more usable md5 validation flow)
- ArciveversionInfo (empty constructor)
- FileIndexReader (use linq instead of XML streams)
- ArchiveVersionIdentifier (use concrete FileSystem class per default)